### PR TITLE
fix: camera jitter when physics interpolation is enabled

### DIFF
--- a/addons/portals/scripts/portal_3d.gd
+++ b/addons/portals/scripts/portal_3d.gd
@@ -497,6 +497,9 @@ func _process_cameras() -> void:
 	portal_camera.near = _calculate_near_plane()
 	portal_camera.fov = player_camera.fov
 	
+	if portal_camera.is_physics_interpolated_and_enabled():
+		portal_camera.reset_physics_interpolation()
+	
 	# Prevent flickering
 	var pv_size: Vector2i = portal_viewport.size
 	var half_height: float = player_camera.near * tan(deg_to_rad(player_camera.fov * 0.5))
@@ -551,7 +554,9 @@ func _process_teleports() -> void:
 					teleportable.linear_velocity.normalized() * rigidbody_boost
 				)
 			
-			
+			if teleportable.is_physics_interpolated_and_enabled():
+				teleportable.reset_physics_interpolation()
+				
 			on_teleport.emit(teleportable)
 			exit_portal.on_teleport_receive.emit(teleportable)
 			


### PR DESCRIPTION
This change removes the jitter visible when passing the player camera through a portal after enabling physics interpolation (in particular when passing the portal sideways).

Related: #12 

Changes I did to test: 
- enable physics interpolation
- set physics jitter to zero (which goes in pair with enabling physics interpolation, see #12 's recommanded video for details)

To be clearer: the project file was modified this way (not included in this patch):
```
[physics]

common/physics_jitter_fix=0.0
3d/physics_engine="Jolt Physics"
common/physics_interpolation=true
```

@VojtaStruhar Could you confirm that you also see no glitch when passing through the portals with this patch after enabling the physics interpolation as described above?

I made it so it doesnt impact the case where interpolation is turned off, I also checked that and didnt see an issue.

HOWEVER: **_this doesnt fix the jitter visible with things going through the portal as seen in Level Smooth_**, it only fixes the jitter of the camera. I'm working on it separately.

