### PR TITLE
Fixes export of Demo project

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -1,24 +1,20 @@
 extends Control
 
-@export_dir var levels_directory: String 
+@export var levels_scenes: Array[PackedScene] = []
 @onready var levels_container: VBoxContainer = %LevelsContainer
 
 
 func _ready() -> void:
 	Input.mouse_mode = Input.MouseMode.MOUSE_MODE_VISIBLE
 	
-	if levels_directory:
-		var dir = DirAccess.open(levels_directory)
-		for file in dir.get_files():
-			if not file.ends_with(".tscn"): continue
-			
-			var b = Button.new()
-			b.text = file.replace(".tscn", "").capitalize()
-			b.pressed.connect(func(): 
-				print("[Level] " + b.text)
-				get_tree().change_scene_to_file(levels_directory + "/" + file)
-			)
-			levels_container.add_child(b)
+	for level_scene in levels_scenes:
+		var b = Button.new()
+		b.text = level_scene.resource_path.get_file().replace(".tscn", "").capitalize()
+		b.pressed.connect(func(): 
+			print("[Level] " + b.text)
+			get_tree().change_scene_to_packed(level_scene)
+		)
+		levels_container.add_child(b)
 
 
 func _on_quit_button_pressed() -> void:

--- a/main.tscn
+++ b/main.tscn
@@ -1,6 +1,18 @@
-[gd_scene load_steps=3 format=3 uid="uid://dfuudoym2pnvu"]
+[gd_scene load_steps=15 format=3 uid="uid://dfuudoym2pnvu"]
 
 [ext_resource type="Script" uid="uid://c8my0avh3yv6i" path="res://main.gd" id="1_ig7tw"]
+[ext_resource type="PackedScene" uid="uid://2c7f2asld8tc" path="res://levels/level_3_rooms.tscn" id="2_ycdy4"]
+[ext_resource type="PackedScene" uid="uid://cceqtevdskikh" path="res://levels/level_around.tscn" id="3_w48qg"]
+[ext_resource type="PackedScene" uid="uid://5vo86e4fice3" path="res://levels/level_basics.tscn" id="4_vivmo"]
+[ext_resource type="PackedScene" uid="uid://coqloab7xvqmb" path="res://levels/level_ceiling.tscn" id="5_2cqfq"]
+[ext_resource type="PackedScene" uid="uid://of26pcjgocig" path="res://levels/level_corridor.tscn" id="6_yaehf"]
+[ext_resource type="PackedScene" uid="uid://cey6k8ip6nn8w" path="res://levels/level_forward.tscn" id="7_074og"]
+[ext_resource type="PackedScene" uid="uid://dxe2g23t2qp0j" path="res://levels/level_island.tscn" id="8_cegan"]
+[ext_resource type="PackedScene" uid="uid://ds6ls70m17lw1" path="res://levels/level_maze.tscn" id="9_82xsv"]
+[ext_resource type="PackedScene" uid="uid://ce6hkiqlckosx" path="res://levels/level_mirror.tscn" id="10_getpj"]
+[ext_resource type="PackedScene" uid="uid://dllqiht0np5i8" path="res://levels/level_physics.tscn" id="11_ryguw"]
+[ext_resource type="PackedScene" uid="uid://6fp86e4fice3" path="res://levels/level_smooth.tscn" id="12_d13ii"]
+[ext_resource type="PackedScene" uid="uid://ds222tuqqcsfc" path="res://levels/level_visuals.tscn" id="13_1u8w0"]
 
 [sub_resource type="LabelSettings" id="LabelSettings_ig7tw"]
 font_size = 32
@@ -15,7 +27,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_ig7tw")
-levels_directory = "res://levels"
+levels_scenes = Array[PackedScene]([ExtResource("2_ycdy4"), ExtResource("3_w48qg"), ExtResource("4_vivmo"), ExtResource("5_2cqfq"), ExtResource("6_yaehf"), ExtResource("7_074og"), ExtResource("8_cegan"), ExtResource("9_82xsv"), ExtResource("10_getpj"), ExtResource("11_ryguw"), ExtResource("12_d13ii"), ExtResource("13_1u8w0")])
 
 [node name="VBoxContainer" type="VBoxContainer" parent="."]
 layout_mode = 1


### PR DESCRIPTION
For some reason the way the level scene files are being searched for only works in the Godot Editor, it doesnt work (no files found) when the project is exported.
I'm not sure why exactly, it might be because there is no explicit reference to the levels as resources to bring along, but when I forced them to be part of the asset pack they where still not found.

So I resorted to rewrite the level list loading by requiring explicitly puting the tscn in the main scene as a packed scene. It's less automatic but probalby is what Godot expect. 

It solves all issues from #17 but only for the demo. I didnt look at the addon's setup yet (I'm not familiar with how addons and export are supposed to interact).
